### PR TITLE
Added Zeros-Poles-Gain Support to Discrete LTI Changes

### DIFF
--- a/scipy/signal/cont2discrete.py
+++ b/scipy/signal/cont2discrete.py
@@ -9,7 +9,7 @@ import numpy as np
 import numpy.linalg
 import scipy.linalg
 
-from ltisys import tf2ss, ss2tf
+from ltisys import tf2ss, ss2tf, zpk2ss, ss2zpk
 
 __all__ = ['cont2discrete']
 
@@ -26,11 +26,11 @@ def cont2discrete(sys, dt, method="zoh"):
     -----------
     sys : a tuple describing the system.
         The following gives the number of elements in the tuple and
-        the interpretation::
-
-          - 2: (num, den)    defining a transfer function
-          - 4: (A, B, C, D)  defining a state-space system
-
+        the interpretation:
+        * 2: (num, den)
+        * 3: (zeros, poles, gain)
+        * 4: (A, B, C, D)
+        
     dt : float
         The discretization time step.
     method : {"bilinear", "zoh"}
@@ -38,12 +38,12 @@ def cont2discrete(sys, dt, method="zoh"):
 
     Returns
     -------
-    sysd : tuple
-        containing the discrete system
-        Based on the input type, the output will be of the form::
-
-          (num, den, dt)   for transfer function input
-          (A, B, C, D, dt) for state-space system input
+    sysd : tuple containing the discrete system
+        Based on the input type, the output will be of the form
+        
+        (num, den, dt)   for transfer function input
+        (zeros, poles, gain, dt)   for zeros-poles-gain input
+        (A, B, C, D, dt) for state-space system input
 
     Notes
     -----
@@ -61,6 +61,9 @@ def cont2discrete(sys, dt, method="zoh"):
     if len(sys) == 2:
         sysd = cont2discrete(tf2ss(sys[0], sys[1]), dt, method=method)
         return ss2tf(sysd[0], sysd[1], sysd[2], sysd[3]) + (dt,)
+    elif len(sys) == 3:
+        sysd = cont2discrete(zpk2ss(sys[0], sys[1], sys[2]), dt, method=method)
+        return ss2zpk(sysd[0], sysd[1], sysd[2], sysd[3]) + (dt,)
     elif len(sys) == 4:
         a, b, c, d = sys
     else:

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -115,6 +115,27 @@ class TestC2D(TestCase):
         assert_array_almost_equal(dend, den)
         
         assert_almost_equal(dt_requested, dt)
+        
+    def test_zerospolesgain(self):
+        
+        zeros_c = np.array([0.5, -0.5])
+        poles_c = np.array([1.j / np.sqrt(2), -1.j / np.sqrt(2)])
+        k_c = 1.0
+        
+        zeros_d = [1.23371727305860, 0.735356894461267]
+        polls_d = [0.938148335039729 + 0.346233593780536j,
+                   0.938148335039729 - 0.346233593780536j]
+        k_d = 1.0
+        
+        dt_requested = 0.5
+        
+        zeros, poles, k, dt = c2d((zeros_c, poles_c, k_c), dt_requested, 
+                                  method='zoh')
+                                
+        assert_array_almost_equal(zeros_d, zeros)
+        assert_array_almost_equal(polls_d, poles)
+        assert_almost_equal(k_d, k)
+        assert_almost_equal(dt_requested, dt)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -5,7 +5,7 @@
 import numpy as np
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
                           assert_array_almost_equal, assert_almost_equal
-from scipy.signal import dlsim, dstep, dimpulse
+from scipy.signal import dlsim, dstep, dimpulse, tf2zpk
 
 class TestDLTI(TestCase):
 
@@ -67,6 +67,17 @@ class TestDLTI(TestCase):
         
         assert_array_almost_equal(yout,yout_truth)
         assert_array_almost_equal(t_in, tout)
+        
+        # zeros-poles-gain representation
+        zd = np.array([0.5, -0.5])
+        pd = np.array([1.j / np.sqrt(2), -1.j / np.sqrt(2)])
+        k = 1.0
+        yout_truth = np.asmatrix([0.0, 1.0, 2.0, 2.25, 2.5]).transpose()
+
+        tout, yout = dlsim((zd, pd, k, 0.5), u[:,0], t_in)
+        
+        assert_array_almost_equal(yout,yout_truth)
+        assert_array_almost_equal(t_in, tout)
 
     def test_dstep(self):
     
@@ -96,6 +107,19 @@ class TestDLTI(TestCase):
         for i in range(0, len(yout)):
             assert_equal(yout[i].shape[0], 10)
             assert_array_almost_equal(yout[i].flatten(), yout_step_truth[i])
+            
+        # Check that the other two inputs (tf, zpk) will work as well
+        tfin = ([1.0,], [1.0, 1.0], 0.5)
+        yout_tfstep = np.asarray([0.0, 1.0, 0.0])
+        tout, yout = dstep(tfin, n=3)
+        assert_equal(len(yout), 1)
+        assert_array_almost_equal(yout[0].flatten(), yout_tfstep)
+        
+        zpkin = tf2zpk(tfin[0], tfin[1]) + (0.5,)
+        tout, yout = dstep(zpkin, n=3)
+        assert_equal(len(yout), 1)
+        assert_array_almost_equal(yout[0].flatten(), yout_tfstep)
+        
 
     def test_dimpulse(self):
         
@@ -124,3 +148,16 @@ class TestDLTI(TestCase):
         for i in range(0, len(yout)):
             assert_equal(yout[i].shape[0], 10)
             assert_array_almost_equal(yout[i].flatten(), yout_imp_truth[i])
+            
+        # Check that the other two inputs (tf, zpk) will work as well
+        tfin = ([1.0,], [1.0, 1.0], 0.5)
+        yout_tfimpulse = np.asarray([0.0, 1.0, -1.0])
+        tout, yout = dimpulse(tfin, n=3)
+        assert_equal(len(yout), 1)
+        assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
+        
+        zpkin = tf2zpk(tfin[0], tfin[1]) + (0.5,)
+        tout, yout = dimpulse(tfin, n=3)
+        assert_equal(len(yout), 1)
+        assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
+        


### PR DESCRIPTION
My original code did not support zeros-poles-gain functionality in discrete form at all.  Before the lti-discrete branch is brought in to scipy:master, it might be a good idea to add this commit to the pull request.
