### PR TITLE
Discrete cleanup

### DIFF
--- a/scipy/signal/cont2discrete.py
+++ b/scipy/signal/cont2discrete.py
@@ -6,7 +6,6 @@ Continuous to discrete transformations for state-space and transfer function.
 # March 29, 2011
 
 import numpy as np
-import numpy.linalg
 import scipy.linalg
 
 from ltisys import tf2ss, ss2tf, zpk2ss, ss2zpk
@@ -67,10 +66,12 @@ def cont2discrete(sys, dt, method="zoh", alpha=None):
 
     """
     if len(sys) == 2:
-        sysd = cont2discrete(tf2ss(sys[0], sys[1]), dt, method=method)
+        sysd = cont2discrete(tf2ss(sys[0], sys[1]), dt, method=method,
+                             alpha=alpha)
         return ss2tf(sysd[0], sysd[1], sysd[2], sysd[3]) + (dt,)
     elif len(sys) == 3:
-        sysd = cont2discrete(zpk2ss(sys[0], sys[1], sys[2]), dt, method=method)
+        sysd = cont2discrete(zpk2ss(sys[0], sys[1], sys[2]), dt, method=method,
+                             alpha=alpha)
         return ss2zpk(sysd[0], sysd[1], sysd[2], sysd[3]) + (dt,)
     elif len(sys) == 4:
         a, b, c, d = sys
@@ -80,10 +81,10 @@ def cont2discrete(sys, dt, method="zoh", alpha=None):
 
     if method == 'gbt':
         if alpha is None:
-            raise ValueError("Alpha paramter must be specified for the "
+            raise ValueError("Alpha parameter must be specified for the "
                              "generalized bilinear transform (gbt) method")
         elif alpha < 0 or alpha > 1:
-            raise ValueError("Alpha paramter must be within the interval "
+            raise ValueError("Alpha parameter must be within the interval "
                              "[0,1] for the gbt method")
 
     if method == 'gbt':
@@ -127,6 +128,6 @@ def cont2discrete(sys, dt, method="zoh", alpha=None):
         dd = d
 
     else:
-        raise ValueError("Unknown transformation method.")
+        raise ValueError("Unknown transformation method '%s'" % method)
 
     return ad, bd, cd, dd, dt

--- a/scipy/signal/dltisys.py
+++ b/scipy/signal/dltisys.py
@@ -30,8 +30,8 @@ def dlsim(system, u, t=None, x0=None):
         assumed between given times).  If there are multiple inputs, then each
         column of the rank-2 array represents an input.
     t : array_like, optional
-        The time steps at which the input is defined and at which the output is
-        desired.
+        The time steps at which the input is defined.  If t is given, the
+        final value in t determines the number of steps returned in the output.
     x0 : arry_like, optional
         The initial conditions on the state vector (zero by default).
 
@@ -48,6 +48,21 @@ def dlsim(system, u, t=None, x0=None):
     See Also
     --------
     lsim, dstep, dimpulse, cont2discrete
+
+    Examples
+    --------
+
+    A simple integrator transfer function with a discrete time step of 1.0
+    could be implemented as:
+    
+    >>> import numpy
+    >>> import scipy.signal
+    >>> tf = ([1.0,], [1.0, -1.0], 1.0)
+    >>> t_in = [0.0, 1.0, 2.0, 3.0]
+    >>> u = numpy.asarray([0.0, 0.0, 1.0, 1.0])
+    >>> t_out, y = scipy.signal.dlsim(tf, u, t=t_in)
+    >>> y
+    array([ 0.,  0.,  0.,  1.])
 
     """
     if len(system) == 3:
@@ -85,7 +100,11 @@ def dlsim(system, u, t=None, x0=None):
     if t is None:
         u_dt = u
     else:
-        u_dt_interp = interp1d(t, u.transpose(), copy=False, bounds_error=True)
+        if len(u.shape) == 1:
+            u_dt_interp = interp1d(t, np.reshape(u,(1,len(u))), copy=False, 
+                                   bounds_error=True)
+        else:
+            u_dt_interp = interp1d(t, u.transpose(), copy=False, bounds_error=True)
         u_dt = u_dt_interp(tout).transpose()
 
     # Simulate the system

--- a/scipy/signal/tests/test_dltisys.py
+++ b/scipy/signal/tests/test_dltisys.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 from numpy.testing import TestCase, run_module_suite, assert_equal, \
-                          assert_array_almost_equal, assert_almost_equal
+                          assert_array_almost_equal
 from scipy.signal import dlsim, dstep, dimpulse, tf2zpk
 
 class TestDLTI(TestCase):
@@ -64,10 +64,18 @@ class TestDLTI(TestCase):
                                   
         # Assume use of the first column of the control input built earlier
         tout, yout = dlsim((num, den, 0.5), u[:,0], t_in)
-        
+
         assert_array_almost_equal(yout,yout_truth)
         assert_array_almost_equal(t_in, tout)
-        
+
+        # Retest the same with a 1-D input vector
+        uflat = np.asarray(u[:,0])
+        uflat = uflat.reshape((5,))
+        tout, yout = dlsim((num, den, 0.5), uflat, t_in)
+
+        assert_array_almost_equal(yout,yout_truth)
+        assert_array_almost_equal(t_in, tout)
+
         # zeros-poles-gain representation
         zd = np.array([0.5, -0.5])
         pd = np.array([1.j / np.sqrt(2), -1.j / np.sqrt(2)])
@@ -148,7 +156,7 @@ class TestDLTI(TestCase):
         for i in range(0, len(yout)):
             assert_equal(yout[i].shape[0], 10)
             assert_array_almost_equal(yout[i].flatten(), yout_imp_truth[i])
-            
+
         # Check that the other two inputs (tf, zpk) will work as well
         tfin = ([1.0,], [1.0, 1.0], 0.5)
         yout_tfimpulse = np.asarray([0.0, 1.0, -1.0])
@@ -157,7 +165,9 @@ class TestDLTI(TestCase):
         assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
         
         zpkin = tf2zpk(tfin[0], tfin[1]) + (0.5,)
-        tout, yout = dimpulse(tfin, n=3)
+        tout, yout = dimpulse(zpkin, n=3)
         assert_equal(len(yout), 1)
         assert_array_almost_equal(yout[0].flatten(), yout_tfimpulse)
-        
+
+if __name__ == "__main__":
+    run_module_suite()


### PR DESCRIPTION
Alpha parameter in cont2discrete now handled for tf and zpk inputs.  dlsim now accepts 1-D input vectors.  Minor string and doc updates.
