### PR TITLE
DOC: Add scipy.sparse release notes.

### DIFF
--- a/doc/release/0.13.0-notes.rst
+++ b/doc/release/0.13.0-notes.rst
@@ -64,16 +64,15 @@ Comparisons with dense matrices and scalars are also supported.
 CSR and CSC fancy indexing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-NOTE: I'm trying to finish this in time.
-
 Compressed sparse row and column sparse matrix types now support fancy indexing
-with boolean matrices, slices, and lists So you can do useful things like::
+with boolean matrices, slices, and lists. So where A is a (CSC or CSR) sparse
+matrix, you can do things like::
 
     >>> A[A > 0.5] = 1  # Since Boolean sparse matrices work!
 
     >>> A[:2, :3] = 2
 
-    >>> A[[1,2], [2]] = 3
+    >>> A[[1,2], 2] = 3
 
 
 ``scipy.special`` improvements


### PR DESCRIPTION
Fancy indexing, boolean spare matrices and comparisons.

I'm still working on fancy indexing. The `__setitem__` part is done, except for handling cases where a matrix of size 0 is returned. `__getitem__` needs some work and more tests though.
