### PR TITLE
TST: normality tests: add a couple of tests for stats vs mstats

### DIFF
--- a/scipy/stats/mstats_basic.py
+++ b/scipy/stats/mstats_basic.py
@@ -1651,9 +1651,9 @@ def skewtest(a, axis=0):
     b2 = skew(a,axis)
     n = a.count(axis)
     if np.min(n) < 8:
-        warnings.warn(
-            "skewtest only valid for n>=8 ... continuing anyway, n=%i" %
-            np.min(n))
+        raise ValueError(
+            "skewtest is not valid with less than 8 samples; %i samples"
+            " were given." % np.min(n))
     y = b2 * ma.sqrt(((n+1)*(n+3)) / (6.0*(n-2)))
     beta2 = (3.0*(n*n+27*n-70)*(n+1)*(n+3)) / ((n-2.0)*(n+5)*(n+7)*(n+9))
     W2 = -1 + ma.sqrt(2*(beta2-1))
@@ -1668,6 +1668,10 @@ skewtest.__doc__ = stats.skewtest.__doc__
 def kurtosistest(a, axis=0):
     a, axis = _chk_asarray(a, axis)
     n = a.count(axis=axis)
+    if np.min(n) < 5:
+        raise ValueError(
+            "kurtosistest requires at least 5 observations; %i observations"
+            " were given." % np.min(n))
     if np.min(n) < 20:
         warnings.warn(
             "kurtosistest only valid for n>=20 ... continuing anyway, n=%i" %

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -15,7 +15,7 @@ from scipy import stats
 from numpy.testing import TestCase, run_module_suite
 from numpy.ma.testutils import (assert_equal, assert_almost_equal,
     assert_array_almost_equal, assert_array_almost_equal_nulp, assert_,
-    assert_allclose)
+    assert_allclose, assert_raises)
 
 
 class TestMquantiles(TestCase):
@@ -521,6 +521,13 @@ class TestNormalitytests():
         assert_array_almost_equal(mstats.skewtest(x), stats.skewtest(x))
         assert_array_almost_equal(mstats.kurtosistest(x),
                                   stats.kurtosistest(x))
+
+        funcs = [stats.normaltest, stats.skewtest, stats.kurtosistest]
+        mfuncs = [mstats.normaltest, mstats.skewtest, mstats.kurtosistest]
+        x = [1, 2, 3, 4]
+        for func, mfunc in zip(funcs, mfuncs):
+            assert_raises(ValueError, func, x)
+            assert_raises(ValueError, mfunc, x)
 
     def test_axis_None(self):
         # Test axis=None (equal to axis=0 for 1-D input)


### PR DESCRIPTION
(am trying on you what you showed me; that monkey with a grenade is back)

it's a nitpick really, making sure that the normality tests behave identically for very small inputs. I guess it's best if both either raise or both warn. Can you have a look if this actually makes sense?
