### PR TITLE
TST: skip test for `stats.ncf.entropy`

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -185,7 +185,7 @@ def test_cont_basic(distname, arg, sn, n_fit_samples):
     check_freezing(distfn, arg)
 
     # Entropy
-    if distname not in ['kstwobign', 'kstwo']:
+    if distname not in ['kstwobign', 'kstwo', 'ncf']:
         check_entropy(distfn, arg, distname)
 
     if distfn.numargs == 0:


### PR DESCRIPTION
The implementation is buggy (see https://github.com/scipy/scipy/issues/2877), and this test is failing with Meson