### PR TITLE
DOC: correct mesondev.sh invocation

### DIFF
--- a/MESON_BUILD.md
+++ b/MESON_BUILD.md
@@ -21,7 +21,7 @@ suite:
 conda env create -f environment.yml
 conda activate scipy-dev
 python -m pip install git+https://github.com/rgommers/meson.git@scipy
-./mesondev.sh build --prefix=$PWD/install
+./mesondev.sh build $PWD/install
 ```
 
 ## Full details and explanation


### PR DESCRIPTION
Doc specifies `--prefix`, but prefix should in fact be simple arg.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->