### PR TITLE
CI: Add compiler caching using ccache for faster builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - meson
 
+env:
+  CCACHE_DIR: "${{ github.workspace }}/.ccache"
+  INSTALLDIR: "installdir"
+
 jobs:
   test_meson:
     name: Meson build
@@ -34,23 +38,62 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libopenblas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libsuitesparse-dev ccache libmpc-dev
 
+    - name: Caching Python dependencies
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip
+
     - name: Install Python packages
       run: |
         python -m pip install numpy setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2 pythran ninja
         python -m pip install git+https://github.com/rgommers/meson.git@fix-cython-mixed-sources
 
+    - name:  Prepare compiler cache
+      id:    prep-ccache
+      shell: bash
+      run: |
+        mkdir -p "${CCACHE_DIR}"
+        echo "::set-output name=dir::$CCACHE_DIR"
+        NOW=$(date -u +"%F-%T")
+        echo "::set-output name=timestamp::${NOW}"
+
+    - name: Setup compiler cache
+      uses:  actions/cache@v2
+      id:    cache-ccache
+      # Reference: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+      # NOTE: The caching strategy is modeled in a way that it will always have a unique cache key for each workflow run
+      # (even if the same workflow is run multiple times). The restore keys are not unique and for a partial match, they will
+      # return the most recently created cache entry, according to the GitHub Action Docs.
+      with:
+        path: ${{ steps.prep-ccache.outputs.dir }}
+        # Restores ccache from either a previous build on this branch or on master
+        key:  ${{ github.workflow }}-${{ matrix.python-version }}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}
+        # This evaluates to `Linux Tests-3.9-ccache-linux-` which is not unique. As the CI matrix is expanded, this will
+        # need to be updated to be unique so that the cache is not restored from a different job altogether.
+        restore-keys: |
+          ${{ github.workflow }}-${{ matrix.python-version }}-ccache-linux-
+
+    - name: Setup build
+      run: |
+        meson setup build --prefix=$PWD/${{ env.INSTALLDIR }}
+
     - name: Build SciPy
       run: |
-        meson setup build --prefix=$PWD/installdir
         ninja -C build -j 2
 
     - name: Install SciPy
       run: |
         meson install -C build
 
+    - name: Ccache performance
+      shell: bash -l {0}
+      run: ccache -s
+
     - name: Test SciPy
       run: |
         export PYTHONPATH="$PWD/installdir/lib/python3.9/site-packages/"
-        pushd installdir
+        pushd ${{ env.INSTALLDIR }}
         python -c "import scipy; import sys; sys.exit(int(not scipy.test(parallel=2)))"
         popd


### PR DESCRIPTION
## Description

This PR:

- Adds caching for Python dependencies 
- Adds compiler caching using `ccache`
- Displays `ccache` performance statistics 

The PR has been tested locally using `act` and over GitHub Actions workflow as well. One of the sample runs can be viewed [here](https://github.com/HarshCasper/scipy-fork/actions/runs/1222063063).