### PR TITLE
BLD: Update meson.build files for C++ Cython support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install numpy setuptools wheel cython pytest pytest-xdist pybind11 pytest-xdist mpmath gmpy2 pythran ninja
-        python -m pip install git+https://github.com/rgommers/meson.git@fix-cython-mixed-sources
+        python -m pip install git+https://github.com/mesonbuild/meson.git@master
 
     - name:  Prepare compiler cache
       id:    prep-ccache

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,7 +90,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate scipy-dev
-        python -m pip install git+https://github.com/rgommers/meson.git@scipy
+        python -m pip install git+https://github.com/mesonbuild/meson.git@master
         CC="ccache $CC" meson setup build --prefix=$PWD/${{ env.INSTALLDIR }}
         ninja -C build -j 2
         meson install -C build

--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -134,13 +134,8 @@ highs_sources = [
   'external/filereaderlp/reader.cpp'
 ]
 
-_highs_wrapper_cpp = custom_target('_highs_wrapper_cpp',
-  output : '_highs_wrapper.cpp',
-  input : 'cython/src/_highs_wrapper.pyx',
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT@', '-o', '@OUTPUT@']
-)
 _highs_wrapper = py3.extension_module('_highs_wrapper',
-  [_highs_wrapper_cpp, highs_sources, ipx_sources],
+  ['cython/src/_highs_wrapper.pyx', highs_sources, ipx_sources],
   include_directories: [
     inc_np,
     # highs_wrapper
@@ -168,17 +163,13 @@ _highs_wrapper = py3.extension_module('_highs_wrapper',
     '-UOSI_FOUND',
     numpy_nodepr_api,
   ],
+  override_options : ['cython_language=cpp'],
   install : true,
   subdir : 'scipy/optimize/_highs'
 )
 
-_highs_constants_cpp = custom_target('_highs_constants_cpp',
-  output : '_highs_constants.cpp',
-  input : 'cython/src/_highs_constants.pyx',
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT@', '-o', '@OUTPUT@']
-)
 _highs_constants = py3.extension_module('_highs_constants',
-  _highs_constants_cpp,
+  'cython/src/_highs_constants.pyx',
   include_directories: [
     'cython/src/',
     'src/',
@@ -187,6 +178,7 @@ _highs_constants = py3.extension_module('_highs_constants',
     'src/simplex/',
   ],
   dependencies: [py3_dep],
+  override_options : ['cython_language=cpp'],
   install : true,
   subdir : 'scipy/optimize/_highs'
 )

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -38,12 +38,6 @@ ckdtree_src = ['ckdtree/src/query.cxx',
   'ckdtree/src/query_ball_tree.cxx',
   'ckdtree/src/sparse_distances.cxx']
 
-ckdtree_cpp = custom_target('ckdtree_cpp',
-  output : 'ckdtree.cpp',
-  input : 'ckdtree.pyx',
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT@', '-o', '@OUTPUT@']
-)
-
 cpp_args = []
 compiler = meson.get_compiler('cpp')
 if compiler.get_id() == 'msvc'
@@ -53,12 +47,13 @@ elif compiler.has_argument('-fvisibility=hidden')
 endif
 
 ckdtree = py3.extension_module('ckdtree',
-  ckdtree_src + [ckdtree_cpp],
+  ckdtree_src + ['ckdtree.pyx'],
   # Cannot use -fnovisibility=hidden for Cython cpp, because it
   # conceals PyInit_ckdtree symbol, and prevents module load.
   cpp_args: ['-Wno-cpp'], # TODO: replace with numpy_nodepr_api
   include_directories: [incdir_numpy, '../_lib', '../_build_utils/src', 'ckdtree/src'],
   dependencies: [py3_dep],
+  override_options : ['cython_language=cpp'],
   install : true,
   subdir : 'scipy/spatial')
 

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -375,17 +375,12 @@ py3.extension_module('_ufuncs',
   subdir : 'scipy/special',
 )
 
-_ufuncs_cxx_cy = custom_target('_ufuncs_cxx_cy',
-  output : '_ufuncs_cxx.cpp',
-  input : cython_special[2],
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT@']
-)
-
 py3.extension_module('_ufuncs_cxx',
-  [ufuncs_cxx_sources, _ufuncs_cxx_cy, _cython_tree],
+  [ufuncs_cxx_sources, cython_special[2], _cython_tree],
   cpp_args : [numpy_nodepr_api, use_math_defines],
   include_directories: [inc_np, '../_lib', '../_build_utils/src'],
   dependencies : [py3_dep, npymath_lib, _ufuncs_pxi_pxd_dep],
+  override_options : ['cython_language=cpp'],
   install : true,
   subdir : 'scipy/special'
 )

--- a/scipy/stats/_boost/meson.build
+++ b/scipy/stats/_boost/meson.build
@@ -11,62 +11,42 @@ endif
 include = include_directories('include')
 inc_boost = include_directories('..' / '..' / '_lib' / 'boost')
 
-# hypergeom_ufunc
-_hypergeom_cy = custom_target('_hypergeom_cy',
-  output : 'hypergeom_ufunc.cpp',
-  input : _stats_gen_pyx[4],  # hypergeom_ufunc.pyx
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT@', '-o', '@OUTPUT@']
-)
 hypergeom_ufunc = py3.extension_module('hypergeom_ufunc',
-    _hypergeom_cy,
+    _stats_gen_pyx[4],
     include_directories: [include, inc_np, inc_boost],
     cpp_args: cpp_args,
     dependencies: [py3_dep],
+    override_options : ['cython_language=cpp'],
     install: true,
     subdir: 'scipy/stats/_boost',
 )
 
-# nbinom_ufunc
-_nbinom_cy = custom_target('_nbinom_cy',
-  output : 'nbinom_ufunc.cpp',
-  input : _stats_gen_pyx[5],  # nbinom_ufunc.pyx
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT@', '-o', '@OUTPUT@']
-)
 nbinom_ufunc = py3.extension_module('nbinom_ufunc',
-    _nbinom_cy,
+    _stats_gen_pyx[5],
     include_directories: [include, inc_np, inc_boost],
     cpp_args: cpp_args,
     dependencies: [py3_dep],
+    override_options : ['cython_language=cpp'],
     install: true,
     subdir: 'scipy/stats/_boost',
 )
 
-# beta_ufunc
-_beta_cy = custom_target('_beta_cy',
-  output : 'beta_ufunc.cpp',
-  input : _stats_gen_pyx[1],  # beta_ufunc.pyx
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT@', '-o', '@OUTPUT@']
-)
 beta_ufunc = py3.extension_module('beta_ufunc',
-    _beta_cy,
+    _stats_gen_pyx[1],
     include_directories: [include, inc_np, inc_boost],
     cpp_args: cpp_args,
     dependencies: [py3_dep],
+    override_options : ['cython_language=cpp'],
     install: true,
     subdir: 'scipy/stats/_boost',
 )
 
-# binom_ufunc
-_binom_cy = custom_target('_binom_cy',
-  output : 'binom_ufunc.cpp',
-  input : _stats_gen_pyx[2],  # binom_ufunc.pyx
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT@', '-o', '@OUTPUT@']
-)
 binom_ufunc = py3.extension_module('binom_ufunc',
-    _binom_cy,
+    _stats_gen_pyx[2],
     include_directories: [include, inc_np, inc_boost],
     cpp_args: cpp_args,
     dependencies: [py3_dep],
+    override_options : ['cython_language=cpp'],
     install: true,
     subdir: 'scipy/stats/_boost',
 )

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -82,16 +82,12 @@ py3.install_sources(
 )
 
 pthread = dependency('threads')
-_qmc_cpp = custom_target('_qmc_cpp',
-  output : '_qmc_cy.cpp',
-  input : '_qmc_cy.pyx',
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT@', '-o', '@OUTPUT@']
-)
 _qmc_cy = py3.extension_module('_qmc_cy',
-  _qmc_cpp,
+  '_qmc_cy.pyx',
   cpp_args: '-Wno-cpp',  # TODO: replace with numpy_nodepr_api
   dependencies : [py3_dep, pthread],
   include_directories : [inc_np],
+  override_options : ['cython_language=cpp'],
   install : true,
   subdir : 'scipy/stats')
 
@@ -125,27 +121,21 @@ _stats_gen_pyx = custom_target('_stats_gen_pyx',
   input : '_generate_pyx.py',
   command : [py3, '@INPUT@', '-o', '@OUTDIR@']
 )
-_biasedurn_cpp = custom_target('_biasedurn_cpp',
-  output : 'biasedurn.cpp',
-  input : [
-    _stats_gen_pyx[0],  # biasedurn.pyx
-    _stats_pxd,
-    _cython_tree,
-  ],
-  command : [cython, '--cplus', '-3', '--fast-fail', '@INPUT0@', '-o', '@OUTPUT@']
-)
+
 biasedurn = py3.extension_module('biasedurn',
-  [_biasedurn_cpp,
+  [_stats_gen_pyx[0],
    'biasedurn/fnchyppr.cpp',
    'biasedurn/impls.cpp',
    'biasedurn/stoc1.cpp',
    'biasedurn/stoc3.cpp',
    'biasedurn/stocR.h', 
    'biasedurn/wnchyppr.cpp',
+   _stats_pxd,
   ],
   cpp_args: ['-DR_BUILD', numpy_nodepr_api],
   include_directories: [inc_np],
-  dependencies: [py3_dep, npyrandom_lib, npymath_lib],
+  dependencies: [py3_dep, npyrandom_lib, npymath_lib, cython_tree],
+  override_options : ['cython_language=cpp'],
   install: true,
   subdir: 'scipy/stats',
 )


### PR DESCRIPTION
Update relevant `meson.build` files to make use of the newly added C++ support for Cython in meson as the intermediate language.

#### Reference issue
Addresses #66 

#### What does this implement/fix?
Skips the intermediate step of converting `.pyx` files to `.cpp` files using `custom_target()`,
instead, uses the new support for C++ Cython in meson to directly provide the `.pxy` file as an input to `python.extension_module()`, with the additional keyword-argument `override_options : ['cython_language=cpp']`

