### PR TITLE
CI: run Linux CI against Meson master nightly

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - meson
+  schedule:
+    - cron: "0 0 * * *" # nightly (done to check changes in Meson master frequently)
 
 env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"


### PR DESCRIPTION
Checks for regressions in Meson that affect the SciPy build.

[ci skip]