### PR TITLE
CI: switch macOS CI to use Meson 0.60.0rc1

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,7 +90,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate scipy-dev
-        python -m pip install git+https://github.com/mesonbuild/meson.git@master
+        python -m pip install meson==0.60.0rc1
         CC="ccache $CC" meson setup build --prefix=$PWD/${{ env.INSTALLDIR }}
         ninja -C build -j 2
         meson install -C build


### PR DESCRIPTION
This is the first Meson release on PyPI that contains what we need to build currently.