### PR TITLE
Allow for Windows paths in generate script

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -1228,9 +1228,9 @@ def get_declaration(ufunc, c_name, c_proto, cy_proto, header,
         # redeclare the function, so that the assumed
         # signature is checked at compile time
         new_name = "%s \"%s\"" % (ufunc.cython_func_name(c_name), c_name)
-        defs.append("cdef extern from \"%s\":" % proto_h_filename)
+        defs.append(f'cdef extern from r"{proto_h_filename}":')
         defs.append("    cdef %s" % (cy_proto.replace('(*)', new_name)))
-        defs_h.append("#include \"%s\"" % header)
+        defs_h.append(f'#include "{header}"')
         defs_h.append("%s;" % (c_proto.replace('(*)', c_name)))
 
     return defs, defs_h, var_name


### PR DESCRIPTION
Write raw strings into pyx files, to allow for backslashes in Windows
paths.


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->