### PR TITLE
Allow copying with script.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ cython = find_program('cython')
 pythran = find_program('pythran')
 generate_f2pymod = files('tools/generate_f2pymod.py')
 tempita = files('scipy/_build_utils/tempita.py')
+copier = find_program(['cp', 'scipy/_build_utils/copyfiles.py'])
 
 # https://mesonbuild.com/Python-module.html
 py_mod = import('python')

--- a/scipy/_build_utils/copyfiles.py
+++ b/scipy/_build_utils/copyfiles.py
@@ -1,20 +1,20 @@
-import os
-from shutil import copyfile
+#!python3
+""" Platform independent file copier script
+"""
+
+import shutil
 import argparse
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--infiles", nargs='+',
+    parser.add_argument("infiles", nargs='+',
                         help="Paths to the input files")
-    parser.add_argument("-o", "--outdir", type=str,
+    parser.add_argument("outdir",
                         help="Path to the output directory")
     args = parser.parse_args()
-
-    outdir_abs = os.path.join(os.getcwd(), args.outdir)
     for infile in args.infiles:
-        outfile = os.path.join(outdir_abs, infile)
-        copyfile(infile, outfile)
+        shutil.copy2(infile, args.outdir)
 
 
 if __name__ == "__main__":

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -11,7 +11,7 @@ _lib_pxd = custom_target('_lib_pxd',
     'ccallback.pxd',
     'messagestream.pxd',
   ],
-  command: ['cp', '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
 _lib_pxd_dep = declare_dependency(sources: _lib_pxd)

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -3,7 +3,7 @@
 __init__py = custom_target('__init__py',
   output: '__init__.py',
   input: '__init__.py',
-  command: ['cp', '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
 cython_linalg = custom_target('cython_linalg',

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -133,7 +133,7 @@ _cython_tree = custom_target('_cython_tree',
     'linalg.pxd',
     'special.pxd'
   ],
-  command: ['cp', '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@']
 )
 cython_tree = declare_dependency(sources: _cython_tree)
 

--- a/scipy/optimize/cython_optimize/meson.build
+++ b/scipy/optimize/cython_optimize/meson.build
@@ -10,7 +10,7 @@ _dummy_init_cyoptimize = custom_target('_dummy_init_cyoptimize',
     'c_zeros.pxd',
     '_zeros.pxd'
   ],
-  command: ['cp', '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
 # FIXME: generated .pyx which has relative cimport in it doesn't work yet (see

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -232,7 +232,7 @@ endif
 _dummy_init_optimize = custom_target('_dummy_init_optimize',
   output: '__init__.py',
   input: '__init__.py',
-  command: ['cp', '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
 _bglu_dense_c = custom_target('_bglu_dense_c',

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -1,7 +1,7 @@
 _spatial_pxd = custom_target('_spatial_pxd',
   output: ['qhull.pxd', 'setlist.pxd'],
   input: ['qhull.pxd', 'setlist.pxd'],
-  command: ['cp', '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
 qhull_src = [

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -73,7 +73,7 @@ _ufuncs_pxi_pxd_sources = custom_target('_ufuncs_pxi_pxd',
     '_ufuncs_extra_code.pxi',
     '_ufuncs_extra_code_common.pxi'
   ],
-  command: ['cp', '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
 _ufuncs_pxi_pxd_dep = declare_dependency(sources: _ufuncs_pxi_pxd_sources)
@@ -394,7 +394,7 @@ special_pxd = declare_dependency(sources: _cython_tree)
 _ellip_harm_pyx = custom_target('_ellip_harm_pyx',
   output: '_ellip_harm_2.pyx',
   input: '_ellip_harm_2.pyx',
-  command: ['cp', '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
 py3.extension_module('_ellip_harm_2',

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -18,7 +18,7 @@ _stats_pxd = custom_target('_stats_pxd',
     'biasedurn.pxd',
     '_unuran/unuran.pxd',
   ],
-  command: ['cp', '@INPUT@', '@OUTDIR@']
+  command: [copier, '@INPUT@', '@OUTDIR@']
 )
 
 statlib_lib = static_library('statlib_lib',


### PR DESCRIPTION
Windows does not have a `cp` binary, and Meson will not
detect a `cp` alias or builtin - so use a script instead.

Repurpose copying script to mimic `cp`.
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->