### PR TITLE
BLD: add command argument to write distribution init

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -324,12 +324,17 @@ if __name__ == '__main__':
     parser.add_argument('--test', nargs='*', default=None,
                         help='Test different architectures. "all", or any of '
                              f'{SUPPORTED_PLATFORMS}')
+    parser.add_argument('--write-init', nargs=1,
+                        metavar='OUT_SCIPY_DIR',
+                        help='Write distribution init to named dir')
     parser.add_argument('--check_version', nargs='?', default='',
                         help='Check provided OpenBLAS version string '
                              'against available OpenBLAS')
     args = parser.parse_args()
     if args.check_version != '':
         test_version(args.check_version)
+    elif args.write_init:
+        make_init(args.write_init[0])
     elif args.test is None:
         print(setup_openblas())
     else:


### PR DESCRIPTION
Allow command line use of openblas_support script to write
distribution_init file for loading openblas DLLs at library load time.

This is useful for making Scipy importable after a meson install, but it also
seems like the write way to prepare an installable distribution.
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->