### PR TITLE
Fix for potentially undefined cpp_args in _uarray

### DIFF
--- a/scipy/_lib/_uarray/meson.build
+++ b/scipy/_lib/_uarray/meson.build
@@ -8,10 +8,12 @@
 
 compiler = meson.get_compiler('cpp')
 
-if compiler.get_id() == 'msvc'
+if compiler.get_id() in ['msvc', 'clang-cl']
   cpp_args = '/EHsc'
 elif compiler.has_argument('-fvisibility=hidden')
   cpp_args = '-fvisibility=hidden'
+else
+  cpp_args = ''
 endif
 
 py3.extension_module('_uarray',


### PR DESCRIPTION
cpp-args can be undefined if using a compiler that isn't
MSVC, and doesn't permit -fvisibility-hidden.

I ran into this using clang-cl.
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->