### PR TITLE
Meson Windows build and CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,76 @@
+on:
+  push:
+    branches:
+      - clean-meson-windows
+  pull_request:
+    branches:
+      - clean-meson-windows
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Choco python
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install python --version=3.9.9 --no-progress
+      - name: set-python-path
+        run: |
+          # Install path, culled from output of Choco install above.
+          $py_dir = 'C:\hostedtoolcache\windows\Python\3.9.9\x64'
+          echo "$py_dir;$py_dir\Scripts;" >> $env:GITHUB_PATH
+      - name: show-python-version
+        run: |
+          python --version
+      - name: install-rtools
+        run: |
+          choco install rtools --no-progress
+          echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
+      - name: show-gfortran
+        run: |
+          gcc --version
+          gfortran --version
+      - name: pip-packages
+        run: |
+          pip install numpy cython pybind11 pythran meson ninja
+      - name: openblas-libs
+        run: |
+          choco install unzip
+          pip install gdown
+          gdown --id 1G3jwxMY4ZVRqvz6owl0kmw_Innmr4ZnV
+          unzip -d c:\ openblas_32_if.zip
+          echo "PKG_CONFIG_PATH=c:\opt\openblas\if_32\64\lib\pkgconfig;" >> $env:GITHUB_ENV
+      - name: meson-configure
+        run: |
+          git submodule update --init --recursive
+          meson build --prefix=$PWD\build
+      - name: meson-build
+        run: |
+          ninja -j 128 -C build
+      - name: meson-install
+        run: |
+          cd build
+          meson install
+      - name: build-path
+        run: |
+          echo "installed_path=$PWD\build\Lib\site-packages" >> $env:GITHUB_ENV
+      - name: post-install
+        run: |
+          $scipy_path = "${env:installed_path}\scipy"
+          $libs_path = "${scipy_path}\.libs"
+          mkdir ${libs_path}
+          $ob_path = (pkg-config --variable libdir openblas) -replace "lib", "bin"
+          cp $ob_path/*.dll $libs_path
+          # Write _distributor_init.py to scipy dir to load .libs DLLs.
+          & python tools\openblas_support.py --write-init $scipy_path
+      - name: prep-test
+        run: |
+          echo "PYTHONPATH=${env:installed_path}" >> $env:GITHUB_ENV
+          pip install pytest-cov
+      - name: test
+        run: |
+          mkdir tmp
+          cd tmp
+          python -c 'import scipy; scipy.test()'

--- a/scipy/fft/_pocketfft/meson.build
+++ b/scipy/fft/_pocketfft/meson.build
@@ -1,7 +1,19 @@
 thread_dep = dependency('threads', required: false)
 
-if thread_dep.found()
-  pocketfft_threads = '-DPOCKETFFT_PTHREADS'
+# mingw-w64 does not implement pthread_pfork, needed by pocket_fft
+win_gcc = is_windows and meson.get_compiler('cpp').get_id() == 'gcc'
+
+pocketfft_threads = []
+fft_deps = [py3_dep]
+if not win_gcc
+  if thread_dep.found()
+    pocketfft_threads += ['-DPOCKETFFT_PTHREADS']
+    fft_deps += [thread_dep]
+  endif
+else
+  # Freezes using threading for mingw-w64 gcc:
+  # https://github.com/mreineck/pocketfft/issues/1
+  pocketfft_threads += ['-DPOCKETFFT_NO_MULTITHREADING']
 endif
 
 #TODO: add the equivalent of set_cxx_flags_hook
@@ -9,7 +21,7 @@ py3.extension_module('pypocketfft',
   'pypocketfft.cxx',
   cpp_args: pocketfft_threads,
   include_directories: inc_pybind11,
-  dependencies: [py3_dep, thread_dep],
+  dependencies: fft_deps,
   gnu_symbol_visibility: 'hidden',
   install: true,
   subdir: 'scipy/fft/_pocketfft',

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -2,8 +2,13 @@
 is_windows = host_machine.system() == 'windows'
 
 if is_windows
+  # For mingw-w64, link statically against the UCRT.
+  gcc_link_args = ['-lucrt', '-static']
   if meson.get_compiler('c').get_id() == 'gcc'
-    add_global_link_arguments('-lucrt', '-static', language: ['c', 'cpp', 'fortran'])
+    add_global_link_arguments(gcc_link_args, language: ['c', 'cpp'])
+    # Force gcc to float64 long doubles for compatibility with MSVC
+    # builds, for C only.
+    add_global_arguments('-mlong-double-64', language: 'c')
     # Manual add of MS_WIN64 macro when not using MSVC.
     # https://bugs.python.org/issue28267
     bitness = run_command('_build_utils/gcc_build_bitness.py').stdout().strip()
@@ -12,6 +17,7 @@ if is_windows
     endif
   endif
   if meson.get_compiler('fortran').get_id() == 'gcc'
+    add_global_link_arguments(gcc_link_args, language: ['fortran'])
     # Flag needed to work around BLAS and LAPACK Gfortran dependence on
     # undocumented C feature when passing single character string
     # arguments.

--- a/scipy/special/tests/test_hyp2f1.py
+++ b/scipy/special/tests/test_hyp2f1.py
@@ -221,7 +221,7 @@ class TestHyp2f1:
                     c=1.3,
                     z=1 + 0j,
                     expected=2.7899070752746906e22 + 0j,
-                    rtol=1e-15
+                    rtol=3e-15
                 ),
             ),
             pytest.param(

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -12,8 +12,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.17'
-OPENBLAS_LONG = 'v0.3.17'
+OPENBLAS_V = '0.3.18'
+OPENBLAS_LONG = 'v0.3.18'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 SUPPORTED_PLATFORMS = [


### PR DESCRIPTION
* Set long double to double with compile flags.
* Relax threshold for hyp2f1 slightly.
* Disable pocketfft threading for now, for mingw build.
* Add Github actions CI for Windows.