### PR TITLE
BLD: meson: fix Clang warnings coming from -Wno-unused-but-set-variable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,11 +11,18 @@ project(
     'cpp_std=c++14',  # TODO: use c++11 if 14 is not available
     # TODO: the below -Wno flags are all needed to silence warnings in
     # f2py-generated code. This should be fixed in f2py itself.
-    'c_args=-Wno-unused-function -Wno-conversion -Wno-unused-but-set-variable -Wno-misleading-indentation -Wno-incompatible-pointer-types',
+    'c_args=-Wno-unused-function -Wno-conversion -Wno-misleading-indentation -Wno-incompatible-pointer-types',
     'fortran_args=-Wno-conversion',
     'fortran_std=legacy',
   ],
 )
+
+cc = meson.get_compiler('c')
+# This argument is called -Wno-unused-but-set-variable by GCC, however Clang
+# doesn't recognize that.
+if cc.has_argument('-Wno-unused-but-set-variable')
+  add_global_arguments('-Wno-unused-but-set-variable', language : 'c')
+endif
 
 # Adding at project level causes many spurious -lgfortran flags.
 add_languages('fortran', native: false)

--- a/scipy/interpolate/meson.build
+++ b/scipy/interpolate/meson.build
@@ -166,6 +166,11 @@ dfitpack = py3.extension_module('dfitpack',
 )
 
 if use_pythran
+  if cc.has_argument('-Wno-unused-but-set-variable')
+    Wno_unused_but_set = ['-Wno-unused-but-set-variable']
+  else
+    Wno_unused_but_set = []
+  endif
   _rbfinterp_pythran = custom_target('_rbfinterp_pythran',
     output: ['_rbfinterp_pythran.cpp'],
     input: '_rbfinterp_pythran.py',
@@ -178,7 +183,7 @@ if use_pythran
       '-Wno-unused-function', '-Wno-unused-variable',
       '-Wno-deprecated-declarations',
       '-Wno-cpp', '-Wno-int-in-bool-context',
-      '-Wno-unused-but-set-variable'
+      Wno_unused_but_set
     ] + cpp_args_pythran,
     include_directories: [incdir_pythran, incdir_numpy],
     dependencies: [py3_dep],

--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -134,6 +134,12 @@ highs_sources = [
   'src/util/stringutil.cpp'
 ]
 
+if cc.has_argument('-Wno-unused-but-set-variable')
+  Wno_unused_but_set = ['-Wno-unused-but-set-variable']
+else
+  Wno_unused_but_set = []
+endif
+
 _highs_wrapper = py3.extension_module('_highs_wrapper',
   ['cython/src/_highs_wrapper.pyx', highs_sources, ipx_sources],
   include_directories: [
@@ -154,7 +160,7 @@ _highs_wrapper = py3.extension_module('_highs_wrapper',
   dependencies: [py3_dep],
   cpp_args: [
     '-Wno-unused-variable',
-    '-Wno-unused-but-set-variable',
+    Wno_unused_but_set,
     highs_define_macros,
     '-UOPENMP',
     '-UEXT_PRESOLVE',


### PR DESCRIPTION
This fixes warnings like these:
```
warning: unknown warning option '-Wno-unused-but-set-variable'; did you mean '-Wno-unused-const-variable'? [-Wunknown-warning-option]
```
There was a warning for every C extension, so by far the noisiest problem on macOS.

There is still another somewhat noisy issue:
```
ld: warning: -pie being ignored. It is only used when linking a main executable
```
This is a known issue, see https://github.com/mesonbuild/meson/issues/4651