### PR TITLE
BLD: add unix-specific build flags to ignore errors

### DIFF
--- a/scipy/optimize/_highs/meson.build
+++ b/scipy/optimize/_highs/meson.build
@@ -197,6 +197,12 @@ else
   Wno_unused_but_set = []
 endif
 
+if host_machine.system() == 'linux'
+  highs_flags = ['-Wno-sign-compare', '-Wno-switch', '-Wno-format-truncation', '-Wno-non-virtual-dtor', '-Wno-class-memaccess']
+else
+  highs_flags = []
+endif
+
 _highs_wrapper = py3.extension_module('_highs_wrapper',
   ['cython/src/_highs_wrapper.pyx', highs_sources, ipx_sources],
   include_directories: [
@@ -219,6 +225,7 @@ _highs_wrapper = py3.extension_module('_highs_wrapper',
   dependencies: [py3_dep],
   cpp_args: [
     '-Wno-unused-variable',
+    highs_flags,
     Wno_unused_but_set,
     highs_define_macros,
     '-UOPENMP',


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/rgommers/scipy/pull/107

#### What does this implement/fix?
<!--Please explain your changes.-->

- compiler flags to match those generated by the HiGHS CMake build system

#### Additional information
<!--Any additional information you think is important.-->

- Unix flags done, now builds on Linux without warnings 
    - `-Wclass-memaccess` is not actually in upstream build flags and emits warnings there too.  Will work on an upstream patch
- Working on Windows/MacOS flags 