### PR TITLE
CI: (mac)Fixes for conda env cache

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,8 +83,7 @@ jobs:
       id: envcache
 
     - name: Update Conda Environment
-      run: mamba env update -n my-env -f environment.yml
-      if: steps.envcache.outputs.cache-hit != 'true'
+      run: mamba env update -n scipy-dev -f environment.yml
 
     - name: Build and Install Scipy
       shell: bash -l {0}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,30 +61,30 @@ jobs:
         restore-keys: |
           ${{ github.workflow }}-${{ matrix.python-version }}-ccache-macos-
 
+    - name: Setup Conda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+        channel-priority: true
+        activate-environment: scipy-dev
+        use-only-tar-bz2: true
+
     - name: Cache conda
       uses: actions/cache@v2
       env:
         # Increase this value to reset cache if environment.yml has not changed
         CACHE_NUMBER: 0
       with:
-        path: ~/conda_pkgs_dir
+        path: /Users/runner/miniconda3/envs/scipy-dev
         key:
           ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
+        id: envcache
 
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
-        channels: conda-forge
-        channel-priority: true
-        environment-file: environment.yml
-        use-only-tar-bz2: true
-
-    - name: Setup Conda Environment
-      shell: bash -l {0}
-      run: |
-        mamba env create -f environment.yml
-        ccache -s
+    - name: Update Conda Environment
+      run: mamba env update -n my-env -f environment.yml
+      if: steps.envcache.outputs.cache-hit != 'true'
 
     - name: Build and Install Scipy
       shell: bash -l {0}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,10 +77,10 @@ jobs:
         # Increase this value to reset cache if environment.yml has not changed
         CACHE_NUMBER: 0
       with:
-        path: /Users/runner/miniconda3/envs/scipy-dev
+        path: /usr/local/miniconda/envs/scipy-dev
         key:
           ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
-        id: envcache
+      id: envcache
 
     - name: Update Conda Environment
       run: mamba env update -n my-env -f environment.yml

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,7 +90,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate scipy-dev
-        python -m pip install meson==0.60.0rc1
+        python -m pip install meson==0.60.3
         CC="ccache $CC" python dev.py -j 2 --build-only
 
     - name: Test Scipy


### PR DESCRIPTION
I think the `conda` environment cache doesn't work due to the following reasons:

1. The environment is already provided while setting the environment.
https://github.com/rgommers/scipy/blob/08fbd7956a0f1b912538638f58f43bd565eb6677/.github/workflows/macos.yml#L74-L81

2. At each run it creates a new environment and installs dependencies.
https://github.com/rgommers/scipy/blob/08fbd7956a0f1b912538638f58f43bd565eb6677/.github/workflows/macos.yml#L86

I found some of these mistakes from GitHub actions docs here: https://github.com/marketplace/actions/setup-miniconda#caching-environments

cc @rgommers 
 