### PR TITLE
BLD: avoid warnings for `fprintf` in f2py-generated C code

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
           gfortran --version
       - name: pip-packages
         run: |
-          pip install numpy cython pybind11 pythran meson ninja
+          pip install numpy==1.21.5 cython pybind11 pythran meson ninja
       - name: openblas-libs
         run: |
           # Download and install pre-built OpenBLAS library

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -1,14 +1,17 @@
 # Platform detection
 is_windows = host_machine.system() == 'windows'
+is_mingw = is_windows and cc.get_id() == 'gcc'
 
 if is_windows
   # For mingw-w64, link statically against the UCRT.
   gcc_link_args = ['-lucrt', '-static']
-  if meson.get_compiler('c').get_id() == 'gcc'
+  if is_mingw
     add_global_link_arguments(gcc_link_args, language: ['c', 'cpp'])
     # Force gcc to float64 long doubles for compatibility with MSVC
     # builds, for C only.
     add_global_arguments('-mlong-double-64', language: 'c')
+    # Make fprintf("%zd") work (see https://github.com/rgommers/scipy/issues/118)
+    add_global_arguments('-D__USE_MINGW_ANSI_STDIO=1', language: ['c', 'cpp'])
     # Manual add of MS_WIN64 macro when not using MSVC.
     # https://bugs.python.org/issue28267
     bitness = run_command('_build_utils/gcc_build_bitness.py').stdout().strip()


### PR DESCRIPTION
These happen for a Mingw-w64 based Windows build, where `%zd` is problematic.

Also pin Windows CI to `numpy==1.21.5`, because `1.22.1` is broken.